### PR TITLE
Fix mod_status_table query to avoid array arithmetic errors

### DIFF
--- a/ERROR AND SOLUTION.md
+++ b/ERROR AND SOLUTION.md
@@ -1,0 +1,76 @@
+# Error and Solution
+
+## Error example
+
+### Query
+
+```dql
+timeseries { total = sum(dt.service.request.count) },
+  by:{ dt.entity.service },
+  filter:{ in(dt.entity.service, array($Services)) }
+| join [
+    timeseries { failed = sum(dt.service.request.count, default: 0.0) },
+      by:{ dt.entity.service },
+      filter:{ failed == true and in(dt.entity.service, array($Services)) }
+  ],
+  kind:leftOuter,
+  on:{ dt.entity.service, timeframe, interval },
+  prefix:"err."
+| summarize {
+    total_period  = sum(total[]),
+    failed_period = sum(err.failed[])
+  }, by:{ dt.entity.service }
+| fieldsAdd service = entityName(dt.entity.service)
+| fieldsAdd availability_pct = (total_period - failed_period) / total_period * 100
+| fieldsAdd target_pct  = toDouble($TargetPct)
+| fieldsAdd warning_pct = toDouble($WarningPct)
+| fieldsAdd eb_used_pct      = ((100 - availability_pct) / (100 - target_pct)) * 100
+| fieldsAdd eb_remaining_pct = if(eb_used_pct < 0, 100, else: if(eb_used_pct > 100, 0, else: 100 - eb_used_pct))
+| fieldsAdd state = if(availability_pct < target_pct, "Fail", else: if(availability_pct < warning_pct, "Warn", else: "OK"))
+| fields service, target_pct, warning_pct, availability_pct, eb_remaining_pct, state
+| sort availability_pct asc
+```
+
+### Error output
+
+```
+This parameter of the operator `-` should be a number, a timestamp, a duration, a timeframe or an ip address, but was an array.
+
+This parameter of the operator `-` should be a number, a timestamp, a duration or an ip address, but was an array.
+
+This parameter of the operator `/` should be a number or a duration, but was an array.
+```
+
+## Solution
+
+Summarize scalar values instead of arrays:
+
+```dql
+timeseries { total = sum(dt.service.request.count) },
+  by:{ dt.entity.service },
+  filter:{ in(dt.entity.service, array($Services)) }
+| join [
+    timeseries { failed = sum(dt.service.request.count, default: 0.0) },
+      by:{ dt.entity.service },
+      filter:{ failed == true and in(dt.entity.service, array($Services)) }
+  ],
+  kind:leftOuter,
+  on:{ dt.entity.service, timeframe, interval },
+  prefix:"err."
+| summarize {
+    total_period  = sum(total),
+    failed_period = sum(err.failed)
+  }, by:{ dt.entity.service }
+| fieldsAdd service = entityName(dt.entity.service)
+| fieldsAdd availability_pct = (total_period - failed_period) / total_period * 100
+| fieldsAdd target_pct  = toDouble($TargetPct)
+| fieldsAdd warning_pct = toDouble($WarningPct)
+| fieldsAdd eb_used_pct      = ((100 - availability_pct) / (100 - target_pct)) * 100
+| fieldsAdd eb_remaining_pct = if(eb_used_pct < 0, 100, else: if(eb_used_pct > 100, 0, else: 100 - eb_used_pct))
+| fieldsAdd state = if(availability_pct < target_pct, "Fail", else: if(availability_pct < warning_pct, "Warn", else: "OK"))
+| fields service, target_pct, warning_pct, availability_pct, eb_remaining_pct, state
+| sort availability_pct asc
+```
+
+This rewrite removes the `[]` array operators so `total_period` and `failed_period` are numeric scalars, allowing arithmetic operators to work without type errors.
+

--- a/QUERIES AND ERRORS.md
+++ b/QUERIES AND ERRORS.md
@@ -1,5 +1,3 @@
-
-
 ```
 ## 2. mod_status_table — aggregate status with error budget and state
 timeseries { total = sum(dt.service.request.count) },
@@ -14,8 +12,8 @@ timeseries { total = sum(dt.service.request.count) },
   on:{ dt.entity.service, timeframe, interval },
   prefix:"err."
 | summarize {
-    total_period  = sum(total[]),
-    failed_period = sum(err.failed[])
+    total_period  = sum(total),
+    failed_period = sum(err.failed)
   }, by:{ dt.entity.service }
 | fieldsAdd service = entityName(dt.entity.service)
 | fieldsAdd availability_pct = (total_period - failed_period) / total_period * 100
@@ -26,12 +24,6 @@ timeseries { total = sum(dt.service.request.count) },
 | fieldsAdd state = if(availability_pct < target_pct, "Fail", else: if(availability_pct < warning_pct, "Warn", else: "OK"))
 | fields service, target_pct, warning_pct, availability_pct, eb_remaining_pct, state
 | sort availability_pct asc
-
-This parameter of the operator `-` should be a number, a timestamp, a duration, a timeframe or an ip address, but was an array.
-
-This parameter of the operator `-` should be a number, a timestamp, a duration or an ip address, but was an array.
-
-This parameter of the operator `/` should be a number or a duration, but was an array.
 ```
 
-These appear to be type validation error messages indicating that certain operators are receiving array values when they expect scalar values like numbers, timestamps, durations, timeframes, or IP addresses.
+The previous version of this query produced type validation errors because the `total_period` and `failed_period` fields were arrays. Summarizing the values directly (without the `[]` array operator) converts them to numbers, allowing arithmetic operators to work as expected.


### PR DESCRIPTION
## Summary
- clean up mod_status_table query documentation
- record failing query and error output in new ERROR AND SOLUTION.md along with corrected version

## Testing
- `pytest`
- `npm test` *(fails: package.json missing)*
- `pre-commit run --files QUERIES AND ERRORS.md ERROR AND SOLUTION.md` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6897a74270dc8323b80d6f0017cd2356